### PR TITLE
Fix /mcp/status 503 console noise on every page (+ 5xx smoke guard)

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -569,14 +569,20 @@ async function startServer() {
           ...mcpStatus
         });
       } else {
-        res.status(503).json({
+        // MCP being offline is a NORMAL, expected state (the MCP server is an
+        // optional subsystem). Report it with 200 + connected:false so the
+        // browser doesn't log a failed-resource error on every page that polls
+        // this; the client already treats connected:false as "offline".
+        res.json({
           connected: false,
+          status: 'offline',
           error: 'MCP server returned an error'
         });
       }
     } catch (error) {
-      res.status(503).json({
+      res.json({
         connected: false,
+        status: 'offline',
         error: error instanceof Error ? error.message : 'Connection failed'
       });
     }

--- a/tests/e2e/user-smoke.spec.ts
+++ b/tests/e2e/user-smoke.spec.ts
@@ -14,9 +14,17 @@ test.describe('user smoke: the app works from a user point of view @smoke', () =
   test('login → graph renders nodes AND edges → no errors anywhere', async ({ page }) => {
     const pageErrors: string[] = [];
     const gqlErrors: string[] = [];
+    const serverErrors: string[] = [];
     page.on('pageerror', (e) => pageErrors.push(e.message));
     page.on('response', async (res) => {
-      if (!res.url().includes('graphql')) return;
+      // Any 5xx from our own origin is a server fault the user shouldn't hit —
+      // e.g. /mcp/status used to 503 on every page when MCP was offline (a
+      // NORMAL state), logging a console error site-wide.
+      const url = res.url();
+      if (res.status() >= 500 && (url.includes('localhost:4127') || url.includes('localhost:3127') || url.includes('/api/'))) {
+        serverErrors.push(`${res.status()} ${url.replace(/^https?:\/\/[^/]+/, '')}`);
+      }
+      if (!url.includes('graphql')) return;
       try {
         const body = await res.json();
         if (body?.errors?.length) {
@@ -77,6 +85,15 @@ test.describe('user smoke: the app works from a user point of view @smoke', () =
 
     // 5) No uncaught JS errors
     expect(pageErrors, `uncaught page errors: ${pageErrors[0] ?? ''}`).toEqual([]);
+
+    // 6) Visit the main routes and confirm none of them produce a 5xx from our
+    //    own origin (catches optional-subsystem endpoints returning 503 for a
+    //    normal "offline" state, which logs a console error site-wide).
+    for (const route of ['/settings', '/backend', '/ontology', '/']) {
+      await page.goto(route).catch(() => {});
+      await page.waitForTimeout(2500);
+    }
+    expect(serverErrors, `server 5xx responses during the session: ${serverErrors[0] ?? ''}`).toEqual([]);
   });
 
   test('grow flow stays healthy: + → empty space → connected named node @smoke', async ({ page }) => {


### PR DESCRIPTION
## Skeptical sweep finding
Visiting every route (desktop + phone) showed **every page logs a console error: `503 /mcp/status`**. MCP is an optional subsystem (AI & Agents are already grayed when it's offline), but the server's status proxy returned **503** for the normal offline state — and browsers log failed resource loads regardless of try/catch, so it was unavoidable site-wide noise (2 console errors per page).

## Fix
`/mcp/status` returns **200 + `{connected:false, status:'offline'}`** when MCP is unreachable. The client already treats `connected:false` as offline → behavior unchanged, console clean. Verified: status now 200; /, /settings, /backend load with **0 console errors** (was 2 each).

## Regression guard
`user-smoke` now fails on **any 5xx from our own origin** during the session and sweeps the main routes — this class of bug was invisible because the gate only inspected GraphQL responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)