### PR TITLE
Fix clone_graph: throws on most graphs and corrupts every edge type

### DIFF
--- a/packages/mcp-server/src/services/graph-service.ts
+++ b/packages/mcp-server/src/services/graph-service.ts
@@ -3586,10 +3586,14 @@ export class GraphService {
         const newGraph = await tx.run(createGraphQuery, {
           newName: args.newName,
           description: `Cloned from: ${sourceGraph.name}`,
-          type: sourceGraph.type,
-          teamId: args.teamId || sourceGraph.teamId,
-          isShared: sourceGraph.isShared,
-          settings: sourceGraph.settings,
+          type: sourceGraph.type ?? 'PROJECT',
+          // Neo4j does not store null-valued properties, so a graph created
+          // without a teamId has NO teamId property — reading it back yields
+          // `undefined`, and the driver rejects an undefined param value with
+          // ParameterMissing. Coalesce to null so clone works for every graph.
+          teamId: args.teamId ?? sourceGraph.teamId ?? null,
+          isShared: sourceGraph.isShared ?? false,
+          settings: sourceGraph.settings ?? '{}',
           sourceGraphId: args.sourceGraphId
         });
 
@@ -3636,12 +3640,11 @@ export class GraphService {
               MATCH (sourceW)-[r:DEPENDS_ON|BLOCKS|RELATES_TO|CONTAINS|PART_OF]->(targetW:WorkItem)-[:BELONGS_TO]->(sourceG)
               MATCH (newG)<-[:BELONGS_TO]-(newTargetW:WorkItem)
               WHERE newTargetW.originalId = targetW.id
-              CREATE (newW)-[newR:DEPENDS_ON {
-                type: r.type,
-                weight: r.weight,
-                metadata: r.metadata
-              }]->(newTargetW)
-              RETURN count(newR) as edgeCount
+              // Preserve the real relationship type — the previous code
+              // hard-coded :DEPENDS_ON, silently rewriting every BLOCKS /
+              // RELATES_TO / CONTAINS / PART_OF edge into a DEPENDS_ON on clone.
+              CALL apoc.create.relationship(newW, type(r), { weight: r.weight, metadata: r.metadata }, newTargetW) YIELD rel
+              RETURN count(rel) as edgeCount
             `;
 
             const edgesResult = await tx.run(cloneEdgesQuery, { 

--- a/packages/mcp-server/tests/neo4j-contract.test.ts
+++ b/packages/mcp-server/tests/neo4j-contract.test.ts
@@ -44,6 +44,9 @@ describe.skipIf(!RUN)('MCP GraphService — real Neo4j contract', () => {
         await session?.run('MATCH (n:WorkItem) WHERE n.id IN $ids DETACH DELETE n', { ids: createdNodes });
       }
       if (createdGraphs.length) {
+        // Also remove any WorkItems that belong to these graphs (clone creates
+        // brand-new node ids we don't otherwise track).
+        await session?.run('MATCH (g:Graph) WHERE g.id IN $ids OPTIONAL MATCH (g)<-[:BELONGS_TO]-(w:WorkItem) DETACH DELETE w', { ids: createdGraphs });
         await session?.run('MATCH (g:Graph) WHERE g.id IN $ids DETACH DELETE g', { ids: createdGraphs });
       }
     } catch { /* ignore */ }
@@ -128,6 +131,53 @@ describe.skipIf(!RUN)('MCP GraphService — real Neo4j contract', () => {
     expect(ctx.counts.nodes, 'two items counted').toBe(2);
     expect(ctx.counts.byType.TASK, 'both items tallied under TASK').toBe(2);
     expect(ctx.counts.byStatus.IN_PROGRESS, 'both items tallied under IN_PROGRESS').toBe(2);
+  });
+
+  it('cloneGraph copies nodes AND preserves each edge type (not all DEPENDS_ON)', async () => {
+    // Regressions this guards:
+    //  1. clone threw ParameterMissing(teamId) because Neo4j never stores a
+    //     null teamId, so reading it back yields undefined.
+    //  2. clone hard-coded :DEPENDS_ON, silently rewriting BLOCKS/RELATES_TO/…
+    const src = parse(await svc.createGraph({ name: `Contract Clone Src ${Date.now()}`, type: 'PROJECT' } as any));
+    const srcId = src.graph.id;
+    createdGraphs.push(srcId);
+
+    const session = driver.session();
+    const mk = async (title: string) => {
+      const id = parse(await svc.createNode({ title, type: 'TASK', status: 'PROPOSED' } as any)).node.id;
+      createdNodes.push(id);
+      await session.run('MATCH (w:WorkItem {id: $id}), (g:Graph {id: $gid}) MERGE (w)-[:BELONGS_TO]->(g)', { id, gid: srcId });
+      return id;
+    };
+    let a: string, b: string, c: string;
+    try {
+      a = await mk(`Clone A ${Date.now()}`);
+      b = await mk(`Clone B ${Date.now()}`);
+      c = await mk(`Clone C ${Date.now()}`);
+    } finally {
+      await session.close();
+    }
+    await svc.createEdge({ source_id: a, target_id: b, type: 'BLOCKS' } as any);
+    await svc.createEdge({ source_id: b, target_id: c, type: 'RELATES_TO' } as any);
+
+    const cloned = parse(await svc.cloneGraph({ sourceGraphId: srcId, newName: `Contract Clone Dst ${Date.now()}` } as any));
+    const dstId = cloned.newGraph.id;
+    createdGraphs.push(dstId);
+    expect(cloned.newGraph.clonedNodes, 'all three nodes cloned').toBe(3);
+    expect(cloned.newGraph.clonedEdges, 'both edges cloned').toBe(2);
+
+    // The cloned edges must keep their real types, not all become DEPENDS_ON
+    const s2 = driver.session();
+    try {
+      const r = await s2.run(
+        'MATCH (g:Graph {id: $gid})<-[:BELONGS_TO]-(:WorkItem)-[rel]->(:WorkItem) RETURN type(rel) AS t ORDER BY t',
+        { gid: dstId }
+      );
+      const types = r.records.map((rec) => rec.get('t')).sort();
+      expect(types, 'cloned relationship types are preserved').toEqual(['BLOCKS', 'RELATES_TO']);
+    } finally {
+      await s2.close();
+    }
   });
 
   it('browseGraph returns well-formed data over a real DB', async () => {


### PR DESCRIPTION
## Summary

Found during the skeptical live-app audit by exercising the `clone_graph` MCP tool against a real Neo4j. It has **two** real, AI-reachable bugs:

### 1. `clone_graph` throws `ParameterMissing: teamId` for most graphs
Neo4j does not store `null`-valued properties, so a graph created without a `teamId` simply has **no** `teamId` property. `cloneGraph` read it back as `undefined` and passed it as a query parameter — and the driver rejects `undefined` param values. So clone threw for essentially every graph created via the MCP API (`createGraph` stores `teamId: null` → property absent).

```
THREW: Expected parameter(s): teamId | Neo.ClientError.Statement.ParameterMissing
```

**Fix:** coalesce `teamId` (and `type`/`isShared`/`settings` defensively) to non-`undefined` values with `?? null`.

### 2. Every cloned edge becomes `DEPENDS_ON`
The edge-clone query matched all relationship types but hard-coded `CREATE (newW)-[:DEPENDS_ON {...}]->(newTargetW)`, so a `BLOCKS` / `RELATES_TO` / `CONTAINS` / `PART_OF` edge was silently rewritten to `DEPENDS_ON` on clone — corrupting the graph's dependency semantics.

**Fix:** `CALL apoc.create.relationship(newW, type(r), {...}, newTargetW)` to preserve the real type. (APOC 5.26 ships with the project's Neo4j.)

## Verification

Before (probe): `clone_graph` threw `ParameterMissing(teamId)`.
After (probe): clones 3 nodes + 2 edges, types preserved as `BLOCKS` and `RELATES_TO`.

## Tests

New real-Neo4j contract case (`MCP Real-Neo4j Contract` CI job): clone a graph containing a `BLOCKS` and a `RELATES_TO` edge → assert all nodes copy and **both edge types survive** (not collapsed to `DEPENDS_ON`).

The existing mock unit tests passed straight through both bugs — they can't reproduce real-DB null-property/relationship-type behavior, which is exactly why the contract test exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)