### PR TITLE
Fix invalid Docker image tag on PRs to main

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,7 +61,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=sha-
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
The `build-and-push` jobs failed on every PR targeting `main` (e.g. the develop→main promotion PR #45) with:

```
ERROR: failed to build: invalid tag "ghcr.io/graphdone/graphdone-web:-69c4029": invalid reference format
```

**Cause:** `docker-publish.yml` had `type=sha,prefix={{branch}}-`. On a `pull_request` event the metadata-action `{{branch}}` placeholder resolves to empty, so the tag became `:-<sha>` (leading dash → invalid reference).

**Fix:** use a static `prefix=sha-`, giving a valid `sha-<shortsha>` tag on branch pushes, version tags, and PRs alike. The other tags (`type=ref,event=pr` → `pr-N`, semver, `latest` on default branch) are unaffected.

This unblocks the prod image pipeline for PRs to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)