### PR TITLE
create_node: attach to a graph + write canonical WorkItem fields (parity with web)

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -116,6 +116,10 @@ const tools: Tool[] = [
           items: { type: 'string' },
           description: 'Array of contributor IDs'
         },
+        graph_id: {
+          type: 'string',
+          description: 'ID of the graph/project this node belongs to. Strongly recommended: the web UI lists nodes per-graph, so a node created without a graph_id is not shown in any graph view. Use list_graphs / create_graph to obtain one.'
+        },
         metadata: {
           type: 'object',
           description: 'Additional metadata for the node'

--- a/packages/mcp-server/src/services/graph-service.ts
+++ b/packages/mcp-server/src/services/graph-service.ts
@@ -63,6 +63,7 @@ export interface CreateNodeArgs {
   status?: NodeStatus;
   contributor_ids?: string[];
   metadata?: NodeMetadata;
+  graph_id?: string;
 }
 
 export interface UpdateNodeArgs {
@@ -465,11 +466,17 @@ export class GraphService {
       // Generate truly unique ID to prevent race conditions
       const id = generateUniqueNodeId();
       const now = new Date().toISOString();
-      
+      const graphId = args.graph_id ? sanitizeNodeId(args.graph_id) : null;
+
       // Use write consistency to prevent read-after-write issues
       return await withWriteConsistency(id, 'CREATE', async () => {
 
+      // Attach the node to its graph via BELONGS_TO when a graph_id is given.
+      // Without this a node is orphaned — the web UI lists nodes per-graph
+      // (workItems where graph.id = currentGraph), so an unattached node an AI
+      // creates is invisible to humans.
       const query = `
+        ${graphId ? 'MATCH (g:Graph {id: $graphId})' : ''}
         CREATE (n:WorkItem {
           id: $id,
           title: $title,
@@ -487,10 +494,11 @@ export class GraphService {
           sphericalPhi: 0,
           metadata: $metadata
         })
+        ${graphId ? 'MERGE (n)-[:BELONGS_TO]->(g)' : ''}
         RETURN n
       `;
 
-      const params = {
+      const params: Record<string, unknown> = {
         id,
         title,
         description,
@@ -499,8 +507,21 @@ export class GraphService {
         now,
         metadata: JSON.stringify(metadata)
       };
+      if (graphId) params.graphId = graphId;
 
       const result = await session.run(query, params);
+
+      // A graph_id that matches no graph yields zero rows (the MATCH fails) —
+      // surface that instead of silently creating nothing.
+      if (graphId && result.records.length === 0) {
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({ error: `Graph with id '${graphId}' not found`, graph_id: graphId }, null, 2)
+          }],
+          isError: true
+        };
+      }
       const rawNode = result.records[0].get('n').properties;
       
       // Parse metadata back from JSON string for data integrity

--- a/packages/mcp-server/src/services/graph-service.ts
+++ b/packages/mcp-server/src/services/graph-service.ts
@@ -331,12 +331,12 @@ export class GraphService {
 
         case 'by_priority':
           const minPriority = filters.min_priority || 0;
-          countQuery = `MATCH (n:WorkItem) WHERE n.priorityComputed >= $min_priority RETURN count(n) as total`;
+          countQuery = `MATCH (n:WorkItem) WHERE n.priorityComp >= $min_priority RETURN count(n) as total`;
           query = `
             MATCH (n:WorkItem)
-            WHERE n.priorityComputed >= $min_priority
+            WHERE n.priorityComp >= $min_priority
             RETURN n
-            ORDER BY n.priorityComputed DESC
+            ORDER BY n.priorityComp DESC
             SKIP $offset
             LIMIT $limit
           `;
@@ -485,13 +485,17 @@ export class GraphService {
           status: $status,
           createdAt: $now,
           updatedAt: $now,
-          priorityExecutive: 0,
-          priorityIndividual: 0,
-          priorityCommunity: 0,
-          priorityComputed: 0,
-          sphericalRadius: 1.0,
-          sphericalTheta: 0,
-          sphericalPhi: 0,
+          positionX: 0,
+          positionY: 0,
+          positionZ: 0,
+          radius: 1.0,
+          theta: 0,
+          phi: 0,
+          priority: 0,
+          priorityComp: 0,
+          priorityExec: 0,
+          priorityIndiv: 0,
+          priorityComm: 0,
           metadata: $metadata
         })
         ${graphId ? 'MERGE (n)-[:BELONGS_TO]->(g)' : ''}
@@ -2198,13 +2202,17 @@ export class GraphService {
         status: $status,
         createdAt: $now,
         updatedAt: $now,
-        priorityExecutive: 0,
-        priorityIndividual: 0,
-        priorityCommunity: 0,
-        priorityComputed: 0,
-        sphericalRadius: 1.0,
-        sphericalTheta: 0,
-        sphericalPhi: 0,
+        positionX: 0,
+        positionY: 0,
+        positionZ: 0,
+        radius: 1.0,
+        theta: 0,
+        phi: 0,
+        priority: 0,
+        priorityComp: 0,
+        priorityExec: 0,
+        priorityIndiv: 0,
+        priorityComm: 0,
         metadata: $metadata
       })
       RETURN n.id as id

--- a/packages/mcp-server/tests/neo4j-contract.test.ts
+++ b/packages/mcp-server/tests/neo4j-contract.test.ts
@@ -245,6 +245,20 @@ describe.skipIf(!RUN)('MCP GraphService — real Neo4j contract', () => {
         { gid: graphId, id }
       );
       expect(r.records[0].get('c').toNumber(), 'node is linked to its graph via BELONGS_TO').toBe(1);
+
+      // The node must carry the CANONICAL schema fields the web reads
+      // (positionX/Y/Z, radius, theta, phi, priority, priorityComp) — not the
+      // old MCP-only names (priorityComputed / sphericalRadius) the web ignores.
+      const fields = await session.run(
+        'MATCH (w:WorkItem {id: $id}) RETURN w.positionX AS px, w.radius AS radius, w.priority AS priority, w.priorityComp AS pc, w.priorityComputed AS legacy',
+        { id }
+      );
+      const rec = fields.records[0];
+      expect(rec.get('px'), 'positionX is set (web reads it)').not.toBeNull();
+      expect(rec.get('radius'), 'radius is set').not.toBeNull();
+      expect(rec.get('priority'), 'priority is set').not.toBeNull();
+      expect(rec.get('pc'), 'priorityComp is set (canonical)').not.toBeNull();
+      expect(rec.get('legacy'), 'no legacy priorityComputed property').toBeNull();
     } finally {
       await session.close();
     }

--- a/packages/mcp-server/tests/neo4j-contract.test.ts
+++ b/packages/mcp-server/tests/neo4j-contract.test.ts
@@ -226,6 +226,38 @@ describe.skipIf(!RUN)('MCP GraphService — real Neo4j contract', () => {
     }
   });
 
+  it('createNode with graph_id attaches via BELONGS_TO (otherwise the node is invisible per-graph)', async () => {
+    // The web lists nodes per-graph (workItems where graph.id = currentGraph),
+    // so a node created without a graph link is invisible to humans. createNode
+    // must attach to the given graph.
+    const g = parse(await svc.createGraph({ name: `Contract Attach ${Date.now()}`, type: 'PROJECT' } as any));
+    const graphId = g.graph.id;
+    createdGraphs.push(graphId);
+
+    const created = parse(await svc.createNode({ title: `Attached ${Date.now()}`, type: 'TASK', graph_id: graphId } as any));
+    const id = created.node.id;
+    createdNodes.push(id);
+
+    const session = driver.session();
+    try {
+      const r = await session.run(
+        'MATCH (g:Graph {id: $gid})<-[:BELONGS_TO]-(w:WorkItem {id: $id}) RETURN count(*) AS c',
+        { gid: graphId, id }
+      );
+      expect(r.records[0].get('c').toNumber(), 'node is linked to its graph via BELONGS_TO').toBe(1);
+    } finally {
+      await session.close();
+    }
+
+    // get_graph_context should now count this node
+    const ctx = parse(await svc.getGraphContext({ graphId } as any)).context;
+    expect(ctx.counts.nodes, 'attached node shows in the graph context').toBeGreaterThanOrEqual(1);
+
+    // A non-existent graph_id is a clean error, not a silent orphan
+    const bad = await svc.createNode({ title: 'Bad Graph', type: 'TASK', graph_id: 'no-such-graph' } as any);
+    expect((bad as { isError?: boolean }).isError, 'unknown graph_id errors').toBe(true);
+  });
+
   it('browseGraph returns well-formed data over a real DB', async () => {
     const browsed = parse(await svc.browseGraph({ query_type: 'all_nodes', limit: 25 } as any));
     const arr = browsed.nodes ?? browsed.results ?? browsed.workItems;


### PR DESCRIPTION
Two related MCP↔web parity bugs in node creation (skeptical audit), both confirmed live and covered by a new real-Neo4j contract test.

## 1. Orphan nodes: `create_node` never attached to a graph
The web lists nodes **per-graph** (`workItems(where: { graph: { id: currentGraph.id } })`), but `create_node` had **no `graph_id` parameter** and never created `BELONGS_TO`. Every node an AI created was orphaned → shown in **no** graph view. This also undermined the edge unify (#47): an AI's nodes never appeared, so neither did edges between them.

**Fix:** optional `graph_id` on the tool + `CreateNodeArgs`; when set, `MATCH (g:Graph {id})` … `MERGE (n)-[:BELONGS_TO]->(g)`. Unknown `graph_id` → clean error, not a silent orphan. Omitting it stays backward-compatible.

## 2. Non-canonical field names
`create_node`/bulk-create wrote `priorityComputed` + `sphericalRadius/Theta/Phi` and **omitted** `positionX/Y/Z`, `priority`, `priorityComp` — but the server schema + web read `positionX/Y/Z, radius, theta, phi, priority, priorityComp`. So AI nodes rendered at priority 0 / the origin, and MCP was internally inconsistent (`createNode`/`browseGraph` used `priorityComputed`; `updateNode` + priority/bottleneck analytics used `priorityComp`).

**Fix:** standardize `createNode` + `executeBulkCreateNode` on the canonical schema fields (keeping the MCP-internal `priorityExec/Indiv/Comm`), and fix `browseGraph by_priority` to read `priorityComp`.

## Verification
Live + contract test: `graph_id` set → `BELONGS_TO` + visible in `get_graph_context`; canonical fields (`positionX`, `radius`, `priority`, `priorityComp`) set, no legacy `priorityComputed`; unknown `graph_id` errors. Full CI-mode unit suite (305) green; contract suite (8) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)