### PR TITLE
Hierarchical graphs PR1: WorkItem drills into a Graph (schema + queries)

### DIFF
--- a/packages/server/src/schema/neo4j-schema.ts
+++ b/packages/server/src/schema/neo4j-schema.ts
@@ -313,6 +313,8 @@ export const typeDefs = gql`
     workItems: [WorkItem!]! @relationship(type: "BELONGS_TO", direction: IN)
     subgraphs: [Graph!]! @relationship(type: "PARENT_OF", direction: OUT)
     parentGraph: Graph @relationship(type: "PARENT_OF", direction: IN)
+    # WorkItems (sheet symbols) that drill into this graph
+    drillSources: [WorkItem!]! @relationship(type: "DRILLS_INTO", direction: IN)
   }
 
   # WorkItem entity - represents work items in the graph
@@ -333,12 +335,17 @@ export const typeDefs = gql`
     dueDate: DateTime
     tags: [String!]
     metadata: String # JSON as string
-    
+    # If set, this node is a "sheet symbol" that drills into another graph
+    # (Altium-style hierarchy). Denormalized id for cheap client-side branching.
+    subgraphId: String
+
     createdAt: DateTime! @timestamp(operations: [CREATE])
     updatedAt: DateTime! @timestamp
 
     # Relationships
     owner: User @relationship(type: "OWNS", direction: IN)
+    # The sub-graph this node drills into (sheet symbol -> sub-sheet)
+    subgraph: Graph @relationship(type: "DRILLS_INTO", direction: OUT)
     assignedTo: User @relationship(type: "ASSIGNED_TO", direction: IN)
     graph: Graph @relationship(type: "BELONGS_TO", direction: OUT)
     dependencies: [WorkItem!]! @relationship(type: "DEPENDS_ON", direction: OUT)

--- a/packages/web/src/lib/queries.ts
+++ b/packages/web/src/lib/queries.ts
@@ -18,6 +18,14 @@ export const GET_WORK_ITEMS = gql`
       dueDate
       tags
       metadata
+      subgraphId
+      subgraph {
+        id
+        name
+        nodeCount
+        edgeCount
+        type
+      }
       owner {
         id
         name
@@ -103,6 +111,14 @@ export const GET_WORK_ITEM_BY_ID = gql`
       dueDate
       tags
       metadata
+      subgraphId
+      subgraph {
+        id
+        name
+        nodeCount
+        edgeCount
+        type
+      }
       owner {
         id
         name

--- a/packages/web/src/types/graph.ts
+++ b/packages/web/src/types/graph.ts
@@ -100,6 +100,15 @@ export interface WorkItem {
   userId?: string;
   dependencies?: WorkItem[];
   dependents?: WorkItem[];
+  // Altium-style hierarchy: if set, this node drills into another graph
+  subgraphId?: string;
+  subgraph?: {
+    id: string;
+    name: string;
+    nodeCount?: number;
+    edgeCount?: number;
+    type?: string;
+  };
 }
 
 // Import and re-export RelationshipType from central constants file


### PR DESCRIPTION
First slice of the Altium-style "graphs of graphs" feature (see approved plan).

A WorkItem can now be a **sheet symbol** that drills into a sub-graph:
- `neo4j-schema.ts`: `WorkItem.subgraph` (`DRILLS_INTO` → Graph) + denormalized `subgraphId` scalar; inverse `Graph.drillSources`. Additive — no Neo4j data migration; existing nodes resolve `null`.
- `queries.ts`: fetch `subgraphId` + `subgraph { id name nodeCount edgeCount type }`.
- `types/graph.ts`: `WorkItem` gains the optional fields.

No behavior change yet — navigation (PR3) and seed data (PR2) build on this.

**Verified:** GraphQL exposes the fields (null for existing nodes), THE GATE 5/5, web+server typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)