### PR TITLE
Graph PR-B: clean (non-overlapping) demo seed spacing + force reseed

### DIFF
--- a/packages/server/src/scripts/create-hierarchy-demo.ts
+++ b/packages/server/src/scripts/create-hierarchy-demo.ts
@@ -1,10 +1,14 @@
 import { driver } from '../db.js';
-import { createHierarchyDemo, hierarchyDemoExists } from '../services/hierarchyDemo.js';
+import { createHierarchyDemo, hierarchyDemoExists, deleteHierarchyDemo } from '../services/hierarchyDemo.js';
 
 async function ensureHierarchyDemo() {
-  console.log('🏗️  Ensuring hierarchical "graphs of graphs" demo exists...\n');
+  const force = process.argv.includes('--force');
+  console.log(`🏗️  Ensuring hierarchical "graphs of graphs" demo exists${force ? ' (force reseed)' : ''}...\n`);
   try {
-    if (await hierarchyDemoExists(driver)) {
+    if (force && (await hierarchyDemoExists(driver))) {
+      await deleteHierarchyDemo(driver);
+    }
+    if (!force && (await hierarchyDemoExists(driver))) {
       console.log('⏭️  Hierarchy demo already exists - skipping creation\n');
     } else {
       const r = await createHierarchyDemo(driver);

--- a/packages/server/src/services/hierarchyDemo.ts
+++ b/packages/server/src/services/hierarchyDemo.ts
@@ -57,7 +57,10 @@ function gridPositions(n: number, spacing: number): Array<{ x: number; y: number
 
 /** A connected sub-graph: backbone chain + deterministic forward links (~1.4x). */
 function buildSubgraph(graphId: string, size: number): { nodes: NodeRow[]; edges: EdgeRow[] } {
-  const pos = gridPositions(size, 140);
+  // Spacing must exceed the node-card collision diameter (~224px) so the seeded
+  // layout is non-overlapping on load — a clean starting state with no physics
+  // needed. (140 produced "garbage piles".)
+  const pos = gridPositions(size, 260);
   const nodes: NodeRow[] = Array.from({ length: size }, (_, i) => {
     const type = NODE_TYPES[(i * 7) % NODE_TYPES.length];
     return {
@@ -89,6 +92,37 @@ function chunk<T>(arr: T[], n: number): T[][] {
   const out: T[][] = [];
   for (let i = 0; i < arr.length; i += n) out.push(arr.slice(i, i + n));
   return out;
+}
+
+/** Demo graph ids (overview + every sub-graph) — for a clean force-reseed. */
+function demoGraphIds(): string[] {
+  return [OVERVIEW_GRAPH_ID, ...SUBSYSTEMS.map((s) => `subgraph-${s.key}-shared`)];
+}
+
+/** Tear down the demo (edges → work items → graphs, in that order so we never
+ *  leave orphan edges). Used by the --force reseed path. */
+export async function deleteHierarchyDemo(driver: Driver): Promise<void> {
+  const session = driver.session();
+  const ids = demoGraphIds();
+  try {
+    await session.run(
+      `UNWIND $ids AS gid
+       MATCH (g:Graph {id: gid})<-[:BELONGS_TO]-(w:WorkItem)
+       OPTIONAL MATCH (w)<-[:EDGE_SOURCE|EDGE_TARGET]-(e:Edge)
+       DETACH DELETE e`,
+      { ids }
+    );
+    await session.run(
+      `UNWIND $ids AS gid
+       MATCH (g:Graph {id: gid})<-[:BELONGS_TO]-(w:WorkItem)
+       DETACH DELETE w`,
+      { ids }
+    );
+    await session.run(`UNWIND $ids AS gid MATCH (g:Graph {id: gid}) DETACH DELETE g`, { ids });
+    console.log(`🗑️  Removed previous hierarchy demo (${ids.length} graphs)`);
+  } finally {
+    await session.close();
+  }
 }
 
 export async function hierarchyDemoExists(driver: Driver): Promise<boolean> {


### PR DESCRIPTION
The demo sub-graphs were seeded on a 140px grid — under the ~224px card collision diameter — so they loaded as overlapping piles.

- `hierarchyDemo.ts`: sub-graph spacing **140 → 260** (> collision diameter) → non-overlapping on load, zero physics cost (important for the 1000-node Compute Core showcase). Nodes stay pinned (no drift).
- `create-hierarchy-demo --force`: tears down the existing demo (edges → work items → graphs, so no orphan edges) and recreates it, to apply the spacing fix to an already-seeded DB.

Pairs with PR-A (one-shot physics): PR-A's Organize/auto-layout cleans *any* graph; PR-B makes the canonical demo clean by construction so it never needs organizing.

**Verified:** reseeded the dev DB (17 graphs / 2911 items / 4073 edges); a 90-node sub-graph has **0 overlapping card pairs**; THE GATE 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)