### PR TITLE
Mobile polish: secondary pages (Ontology/Admin/Agents) + quiet OAuth-config log

### DIFF
--- a/packages/web/src/pages/Admin.tsx
+++ b/packages/web/src/pages/Admin.tsx
@@ -759,7 +759,7 @@ function DatabaseManagement() {
         </div>
         
         {/* Database Statistics */}
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 sm:gap-4 mb-6">
           <div className="bg-gray-700 border border-gray-600 rounded-lg p-4">
             <div className="flex items-center justify-between">
               <div>
@@ -816,7 +816,7 @@ function DatabaseManagement() {
         </div>
 
         {/* Quick Actions */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mb-6">
           <button
             onClick={async () => {
               const debug = [...debugInfo];
@@ -1340,7 +1340,7 @@ certbot renew --dry-run
                 </defs>
               </svg>
               
-              <div className="mt-4 grid grid-cols-2 md:grid-cols-4 gap-3 text-xs">
+              <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3 text-xs">
                 <div className="flex items-center space-x-2" title="End user browsers connecting via HTTPS">
                   <div className="w-3 h-3 bg-blue-500/30 border border-blue-500 rounded"></div>
                   <span className="text-blue-300">Client Browser</span>

--- a/packages/web/src/pages/Agents.tsx
+++ b/packages/web/src/pages/Agents.tsx
@@ -111,8 +111,8 @@ export function Agents() {
   return (
     <div className="h-full flex flex-col">
       {/* Header */}
-      <div className="bg-gray-900/30 backdrop-blur-md border-b border-gray-700/30 px-6 py-4">
-        <div className="flex items-center justify-between">
+      <div className="bg-gray-900/30 backdrop-blur-md border-b border-gray-700/30 px-3 py-3 sm:px-6 sm:py-4">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
           <div>
             <div className="flex items-center space-x-3">
               <h1 className="text-2xl font-bold text-gray-100">AI & Agents</h1>
@@ -125,7 +125,7 @@ export function Agents() {
             </p>
           </div>
           
-          <div className="flex items-center space-x-3">
+          <div className="flex flex-wrap items-center gap-2 sm:gap-3">
             <button
               type="button"
               onClick={() => setSettingsModalOpen(true)}

--- a/packages/web/src/pages/Ontology.tsx
+++ b/packages/web/src/pages/Ontology.tsx
@@ -195,7 +195,7 @@ export function Ontology() {
         {activeTab === 'types' && (
           <div className="p-6">
             {/* Search and filters */}
-            <div className="mb-6 flex items-center space-x-4">
+            <div className="mb-6 flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">
               <div className="flex-1 relative">
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
                 <input
@@ -288,7 +288,7 @@ export function Ontology() {
         {activeTab === 'relationships' && (
           <div className="p-6">
             {/* Search and filters */}
-            <div className="mb-6 flex items-center space-x-4">
+            <div className="mb-6 flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">
               <div className="flex-1 relative">
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
                 <input

--- a/packages/web/src/pages/Signin.tsx
+++ b/packages/web/src/pages/Signin.tsx
@@ -122,8 +122,10 @@ export function Signin() {
             setOauthConfig(config.oauth.providers);
           }
         }
-      } catch (error) {
-        console.error('Failed to fetch OAuth config:', error);
+      } catch {
+        // OAuth config is optional (e.g. the D1-first cloud has no OAuth backend);
+        // a fetch failure just means "no social providers", not an app error.
+        console.debug('OAuth config unavailable; hiding social sign-in.');
       }
     };
     fetchOAuthConfig();

--- a/packages/web/src/pages/Signup.tsx
+++ b/packages/web/src/pages/Signup.tsx
@@ -259,8 +259,8 @@ export function Signup() {
             setOauthConfig(config.oauth.providers);
           }
         }
-      } catch (error) {
-        console.error('Failed to fetch OAuth config:', error);
+      } catch {
+        console.debug('OAuth config unavailable; hiding social sign-up.');
       }
     };
     fetchOAuthConfig();


### PR DESCRIPTION
Follow-up to #77 — sweeps the non-workspace pages for phone-width overflow/squeeze (from a mobile audit).

- **Ontology**: search/filter rows stack on mobile instead of crushing the input.
- **Admin**: DB-stats grid 2-up on phones (was 1 tiny col); quick-actions + TLS legend collapse responsively.
- **Agents**: header stacks title/actions on mobile; action buttons wrap.
- **Sign-in/up**: optional OAuth-config fetch failure (expected on D1-first cloud) logs at `debug`, not a red console error.

Web typecheck clean. No graph-canvas or data-path changes.