### PR TITLE
feat(a11y): modal focus-trap + restore + role=dialog, with @a11y tests

### DIFF
--- a/packages/web/src/components/CreateGraphModal.tsx
+++ b/packages/web/src/components/CreateGraphModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { useDialog } from '../hooks/useDialogManager';
+import { useModalA11y } from '../hooks/useModalA11y';
 import { X, Folder, FolderOpen, Plus, Copy, FileText } from 'lucide-react';
 import { useGraph } from '../contexts/GraphContext';
 import { useAuth } from '../contexts/AuthContext';
@@ -14,6 +15,8 @@ interface CreateGraphModalProps {
 
 export function CreateGraphModal({ isOpen, onClose, parentGraphId }: CreateGraphModalProps) {
   useDialog(isOpen, onClose);
+  const panelRef = useRef<HTMLDivElement>(null);
+  useModalA11y(panelRef, { isOpen, label: 'Create new graph' });
   const { currentTeam, currentUser } = useAuth();
   const { createGraph, duplicateGraph, availableGraphs, isCreating } = useGraph();
   const { showSuccess, showError } = useNotifications();
@@ -219,7 +222,7 @@ export function CreateGraphModal({ isOpen, onClose, parentGraphId }: CreateGraph
         />
 
         {/* Modern eye-catching modal */}
-        <div className="inline-block w-full max-w-2xl p-0 my-8 overflow-hidden text-left align-middle transition-all transform bg-gradient-to-br from-gray-800/98 via-gray-850/98 to-gray-900/98 backdrop-blur-2xl shadow-2xl rounded-2xl border border-gray-600/30 animate-in slide-in-from-bottom-4 duration-300 relative">
+        <div ref={panelRef} className="inline-block w-full max-w-2xl p-0 my-8 overflow-hidden text-left align-middle transition-all transform bg-gradient-to-br from-gray-800/98 via-gray-850/98 to-gray-900/98 backdrop-blur-2xl shadow-2xl rounded-2xl border border-gray-600/30 animate-in slide-in-from-bottom-4 duration-300 relative">
           {/* Animated gradient border */}
           <div className="absolute inset-0 rounded-2xl bg-gradient-to-r from-blue-500/20 via-purple-500/20 to-green-500/20 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none"></div>
           <div className="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-blue-500 via-purple-500 via-pink-500 to-green-500"></div>

--- a/packages/web/src/components/CreateGraphModal.tsx
+++ b/packages/web/src/components/CreateGraphModal.tsx
@@ -249,6 +249,7 @@ export function CreateGraphModal({ isOpen, onClose, parentGraphId }: CreateGraph
             </div>
             <button
               onClick={handleClose}
+              aria-label="Close"
               className="p-2 text-gray-400 hover:text-white hover:bg-red-600 rounded-lg transition-all duration-200 hover:scale-110"
             >
               <X className="h-5 w-5" />

--- a/packages/web/src/components/CreateWorkItemModal.tsx
+++ b/packages/web/src/components/CreateWorkItemModal.tsx
@@ -374,6 +374,7 @@ export function CreateWorkItemModal({ isOpen, onClose, parentWorkItemId, positio
             </div>
             <button
               onClick={onClose}
+              aria-label="Close"
               className="p-2 text-gray-400 hover:text-white hover:bg-red-600 rounded-lg transition-all duration-200 hover:scale-110"
             >
               <X className="h-5 w-5" />

--- a/packages/web/src/components/CreateWorkItemModal.tsx
+++ b/packages/web/src/components/CreateWorkItemModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createPortal } from 'react-dom';
 import { useDialog } from '../hooks/useDialogManager';
+import { useModalA11y } from '../hooks/useModalA11y';
 import { useMutation, useQuery } from '@apollo/client';
 import { X, Link, ChevronDown, Plus } from 'lucide-react';
 import { CREATE_WORK_ITEM, GET_WORK_ITEMS, GET_EDGES, CREATE_EDGE } from '../lib/queries';
@@ -50,6 +51,8 @@ interface CreateWorkItemModalProps {
 
 export function CreateWorkItemModal({ isOpen, onClose, parentWorkItemId, position, onSubmit }: CreateWorkItemModalProps) {
   useDialog(isOpen, onClose);
+  const panelRef = React.useRef<HTMLDivElement>(null);
+  useModalA11y(panelRef, { isOpen, label: parentWorkItemId ? 'Create and connect work item' : 'Create new work item' });
   const { currentUser, currentTeam } = useAuth();
   const { currentGraph } = useGraph();
   const { showSuccess, showError } = useNotifications();
@@ -345,7 +348,7 @@ export function CreateWorkItemModal({ isOpen, onClose, parentWorkItemId, positio
           onClick={onClose}
         />
 
-        <div className="inline-block w-full max-w-lg p-0 my-8 overflow-hidden text-left align-middle transition-all transform bg-gradient-to-br from-gray-800/98 via-gray-850/98 to-gray-900/98 backdrop-blur-2xl shadow-2xl rounded-2xl border border-gray-600/30 focus-within:ring-2 focus-within:ring-blue-500/50 animate-in slide-in-from-bottom-4 duration-300 relative" onClick={(e) => e.stopPropagation()}>
+        <div ref={panelRef} className="inline-block w-full max-w-lg p-0 my-8 overflow-hidden text-left align-middle transition-all transform bg-gradient-to-br from-gray-800/98 via-gray-850/98 to-gray-900/98 backdrop-blur-2xl shadow-2xl rounded-2xl border border-gray-600/30 focus-within:ring-2 focus-within:ring-blue-500/50 animate-in slide-in-from-bottom-4 duration-300 relative" onClick={(e) => e.stopPropagation()}>
           <div className="absolute inset-0 rounded-2xl bg-gradient-to-r from-blue-500/20 via-purple-500/20 to-green-500/20 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none"></div>
           <div className="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-blue-500 via-purple-500 via-pink-500 to-green-500"></div>
 

--- a/packages/web/src/components/WorkItemDetailsModal.tsx
+++ b/packages/web/src/components/WorkItemDetailsModal.tsx
@@ -106,12 +106,11 @@ export function WorkItemDetailsModal({
   useEffect(() => {
     if (!isOpen) return;
 
+    // Escape is handled centrally by useDialog (defers while typing in a field,
+    // and keeps the dialog-manager's "close top-most" stack coherent). Here we
+    // only add the Ctrl/Cmd+S save shortcut.
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.stopPropagation();
-        e.preventDefault();
-        onClose();
-      } else if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
         e.stopPropagation();
         e.preventDefault();
         if (handleSaveRef.current) {

--- a/packages/web/src/components/WorkItemDetailsModal.tsx
+++ b/packages/web/src/components/WorkItemDetailsModal.tsx
@@ -11,6 +11,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { useGraph } from '../contexts/GraphContext';
 import { useNotifications } from '../contexts/NotificationContext';
 import { useDialog } from '../hooks/useDialogManager';
+import { useModalA11y } from '../hooks/useModalA11y';
 import {
   Calendar, Clock,
   Layers, Trophy, Target, ListTodo, AlertTriangle, Lightbulb, Microscope,
@@ -80,8 +81,12 @@ export function WorkItemDetailsModal({
   const disconnectDropdownRef = useRef<HTMLDivElement>(null);
   const datePickerRef = useRef<HTMLDivElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   useDialog(isOpen, onClose);
+  // Container already manages its own initial focus (modalRef) below; this adds
+  // the Tab focus-trap + focus-restore-to-trigger on top.
+  useModalA11y(dialogRef, { isOpen, initialFocus: false });
 
   useEffect(() => {
     if (node) {
@@ -516,10 +521,11 @@ export function WorkItemDetailsModal({
 
   return createPortal((
     <div
+      ref={dialogRef}
       className="fixed inset-0 bg-black/70 backdrop-blur-lg z-50 flex items-stretch sm:items-center justify-center p-0 sm:p-4"
       role="dialog"
       aria-modal="true"
-      aria-labelledby="modal-title"
+      aria-label="Work item details"
     >
       <div
         className="fixed inset-0 cursor-pointer"

--- a/packages/web/src/hooks/useModalA11y.ts
+++ b/packages/web/src/hooks/useModalA11y.ts
@@ -1,0 +1,107 @@
+import { RefObject, useEffect } from 'react';
+
+/**
+ * Accessibility primitive for modal dialogs. When `isOpen`, it:
+ *  - marks the container as role="dialog" aria-modal="true" (keeps an existing
+ *    role if one is already set) and labels it (aria-label / aria-labelledby);
+ *  - moves focus into the dialog on open (first focusable, or the container);
+ *  - traps Tab / Shift+Tab so keyboard focus cycles WITHIN the dialog instead of
+ *    leaking to the page behind it;
+ *  - restores focus to whatever was focused before it opened (the trigger) on
+ *    close, so keyboard users land back where they were.
+ *
+ * Pair it with `useDialog` (Escape / click-outside) for the full contract.
+ */
+
+const FOCUSABLE = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+interface ModalA11yOptions {
+  isOpen: boolean;
+  /** Accessible name for the dialog (used when there's no visible heading id). */
+  label?: string;
+  /** id of a visible heading element; takes precedence over `label`. */
+  labelledBy?: string;
+  /** Move focus into the dialog on open (default true). Pass false when the
+   *  component already manages its own initial focus. */
+  initialFocus?: boolean;
+}
+
+function isVisible(el: HTMLElement): boolean {
+  return el.offsetWidth > 0 || el.offsetHeight > 0 || el === document.activeElement;
+}
+
+export function useModalA11y(ref: RefObject<HTMLElement>, opts: ModalA11yOptions): void {
+  const { isOpen, label, labelledBy, initialFocus = true } = opts;
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!isOpen || !el) return;
+
+    if (!el.getAttribute('role')) el.setAttribute('role', 'dialog');
+    el.setAttribute('aria-modal', 'true');
+    if (labelledBy) el.setAttribute('aria-labelledby', labelledBy);
+    else if (label && !el.getAttribute('aria-labelledby')) el.setAttribute('aria-label', label);
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    const focusables = () =>
+      Array.from(el.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(isVisible);
+
+    let raf = 0;
+    if (initialFocus) {
+      // Defer past paint so portaled inputs/buttons exist before we grab focus.
+      raf = requestAnimationFrame(() => {
+        const items = focusables();
+        if (items[0]) {
+          items[0].focus({ preventScroll: true });
+        } else {
+          if (!el.getAttribute('tabindex')) el.setAttribute('tabindex', '-1');
+          el.focus({ preventScroll: true });
+        }
+      });
+    }
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+      const items = focusables();
+      if (items.length === 0) {
+        e.preventDefault();
+        el.focus({ preventScroll: true });
+        return;
+      }
+      const first = items[0];
+      const last = items[items.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey) {
+        if (active === first || !el.contains(active)) {
+          e.preventDefault();
+          last.focus({ preventScroll: true });
+        }
+      } else if (active === last || !el.contains(active)) {
+        e.preventDefault();
+        first.focus({ preventScroll: true });
+      }
+    };
+    el.addEventListener('keydown', onKeyDown);
+
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+      el.removeEventListener('keydown', onKeyDown);
+      if (
+        previouslyFocused &&
+        previouslyFocused !== document.body &&
+        document.contains(previouslyFocused) &&
+        typeof previouslyFocused.focus === 'function'
+      ) {
+        previouslyFocused.focus({ preventScroll: true });
+      }
+    };
+  }, [isOpen, label, labelledBy, initialFocus, ref]);
+}

--- a/packages/web/src/hooks/useModalA11y.ts
+++ b/packages/web/src/hooks/useModalA11y.ts
@@ -2,15 +2,19 @@ import { RefObject, useEffect } from 'react';
 
 /**
  * Accessibility primitive for modal dialogs. When `isOpen`, it:
- *  - marks the container as role="dialog" aria-modal="true" (keeps an existing
- *    role if one is already set) and labels it (aria-label / aria-labelledby);
- *  - moves focus into the dialog on open (first focusable, or the container);
- *  - traps Tab / Shift+Tab so keyboard focus cycles WITHIN the dialog instead of
- *    leaking to the page behind it;
- *  - restores focus to whatever was focused before it opened (the trigger) on
- *    close, so keyboard users land back where they were.
+ *  - marks the container role="dialog" aria-modal="true" (keeps an existing role)
+ *    and gives it an accessible name (aria-label / aria-labelledby);
+ *  - moves focus into the dialog on open (the first form field if there is one,
+ *    else the first focusable, else the container);
+ *  - traps Tab / Shift+Tab so KEYBOARD focus cycles within the dialog instead of
+ *    tabbing out to the page behind it;
+ *  - restores focus to the trigger on close (only when focus fell back to <body>,
+ *    so it never fights a close that deliberately moved focus elsewhere).
  *
- * Pair it with `useDialog` (Escape / click-outside) for the full contract.
+ * Scope note: this is a Tab-focus trap + aria-modal hint. It does NOT make the
+ * background `inert`, so it doesn't block mouse clicks or an AT virtual cursor
+ * from reaching content behind the dialog — pair it with `useDialog` (Escape /
+ * click-outside) and rely on the visual backdrop for pointer dismissal.
  */
 
 const FOCUSABLE = [
@@ -19,6 +23,7 @@ const FOCUSABLE = [
   'input:not([disabled])',
   'select:not([disabled])',
   'textarea:not([disabled])',
+  '[contenteditable]:not([contenteditable="false"])',
   '[tabindex]:not([tabindex="-1"])',
 ].join(',');
 
@@ -34,8 +39,14 @@ interface ModalA11yOptions {
 }
 
 function isVisible(el: HTMLElement): boolean {
-  return el.offsetWidth > 0 || el.offsetHeight > 0 || el === document.activeElement;
+  if (el === document.activeElement) return true;
+  if (el.getClientRects().length === 0) return false;
+  const cs = getComputedStyle(el);
+  return cs.visibility !== 'hidden' && cs.display !== 'none';
 }
+
+const isField = (el: HTMLElement) =>
+  /^(INPUT|TEXTAREA|SELECT)$/.test(el.tagName) && (el as HTMLInputElement).type !== 'hidden';
 
 export function useModalA11y(ref: RefObject<HTMLElement>, opts: ModalA11yOptions): void {
   const { isOpen, label, labelledBy, initialFocus = true } = opts;
@@ -56,11 +67,13 @@ export function useModalA11y(ref: RefObject<HTMLElement>, opts: ModalA11yOptions
 
     let raf = 0;
     if (initialFocus) {
-      // Defer past paint so portaled inputs/buttons exist before we grab focus.
+      // Defer past paint so portaled fields/buttons exist before we grab focus,
+      // and prefer the first real form field over an icon-only Close button.
       raf = requestAnimationFrame(() => {
         const items = focusables();
-        if (items[0]) {
-          items[0].focus({ preventScroll: true });
+        const target = items.find(isField) || items[0];
+        if (target) {
+          target.focus({ preventScroll: true });
         } else {
           if (!el.getAttribute('tabindex')) el.setAttribute('tabindex', '-1');
           el.focus({ preventScroll: true });
@@ -94,7 +107,12 @@ export function useModalA11y(ref: RefObject<HTMLElement>, opts: ModalA11yOptions
     return () => {
       if (raf) cancelAnimationFrame(raf);
       el.removeEventListener('keydown', onKeyDown);
+      // Restore focus to the trigger ONLY if focus dropped to <body> as the
+      // dialog unmounted — never override a close that intentionally moved focus.
+      const active = document.activeElement as HTMLElement | null;
+      const focusDropped = !active || active === document.body;
       if (
+        focusDropped &&
         previouslyFocused &&
         previouslyFocused !== document.body &&
         document.contains(previouslyFocused) &&

--- a/tests/e2e/a11y-focus.spec.ts
+++ b/tests/e2e/a11y-focus.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect, Page } from '@playwright/test';
+import { login, TEST_USERS, getBaseURL } from '../helpers/auth';
+
+/**
+ * Modal accessibility / keyboard-focus gate (@a11y). Asserts the contract added
+ * by useModalA11y: a modal is exposed as role="dialog" aria-modal with an
+ * accessible name, keyboard focus MOVES INTO it on open, Tab/Shift+Tab is
+ * TRAPPED within it (never leaks to the page behind), and focus is RESTORED to
+ * the trigger on close. These were entirely untested and mostly unimplemented;
+ * a modal you can Tab out of (into the graph behind it) is real keyboard friction.
+ */
+
+const FOCUSABLE =
+  'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])';
+
+async function openWorkspace(page: Page, viewMode = 'cards') {
+  await login(page, TEST_USERS.ADMIN);
+  await page.addInitScript((m) => localStorage.setItem('graphdone:viewMode', m), viewMode);
+  await page.goto(`${getBaseURL()}/`, { waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(3000);
+}
+
+const focusWithinDialog = (page: Page) =>
+  page.evaluate(() => {
+    const d = document.querySelector('[role="dialog"][aria-modal="true"]');
+    return !!d && !!document.activeElement && d.contains(document.activeElement);
+  });
+
+/** Focus the first focusable in the dialog, then Tab `presses` times; focus must
+ *  stay inside the dialog the whole time (the trap). Returns true if it never escaped. */
+async function tabStaysTrapped(page: Page, presses = 14): Promise<boolean> {
+  await page.evaluate((sel) => {
+    const d = document.querySelector('[role="dialog"][aria-modal="true"]');
+    const f = d?.querySelector(sel) as HTMLElement | null;
+    f?.focus();
+  }, FOCUSABLE);
+  for (let i = 0; i < presses; i++) {
+    await page.keyboard.press('Tab');
+    if (!(await focusWithinDialog(page))) return false;
+  }
+  // and a few back-tabs
+  for (let i = 0; i < 4; i++) {
+    await page.keyboard.press('Shift+Tab');
+    if (!(await focusWithinDialog(page))) return false;
+  }
+  return true;
+}
+
+test.describe('modal a11y: role + focus trap + restore @a11y', () => {
+  test.describe.configure({ timeout: 90_000 });
+
+  test.describe('desktop', () => {
+    test.use({ viewport: { width: 1440, height: 900 } });
+
+    test('work-item details modal: role=dialog, accessible name, focus trapped', async ({ page }) => {
+      await openWorkspace(page, 'cards');
+      await page.locator('[data-testid="view-content"] .grid > div').first().click().catch(() => {});
+      await page.waitForTimeout(1200);
+      const badge = page.locator('[data-testid="details-type-badge"]');
+      if (!(await badge.isVisible().catch(() => false))) test.skip(true, 'details modal did not open');
+
+      const dialog = page.locator('[role="dialog"][aria-modal="true"]');
+      await expect(dialog, 'exposed as a modal dialog').toBeVisible();
+      await expect(dialog, 'has an accessible name').toHaveAttribute('aria-label', /.+/);
+      expect(await tabStaysTrapped(page), 'Tab focus stays within the details modal').toBe(true);
+    });
+
+    test('create-graph modal: role=dialog and focus trapped', async ({ page }) => {
+      await openWorkspace(page, 'cards');
+      const sel = page.locator('[data-testid="graph-selector"]');
+      let trigger = null as any;
+      for (let i = 0; i < (await sel.count()); i++) {
+        if (await sel.nth(i).isVisible().catch(() => false)) { trigger = sel.nth(i); break; }
+      }
+      if (!trigger) test.skip(true, 'no graph selector');
+      await trigger.click();
+      await page.waitForTimeout(400);
+      const create = page.locator('[title="Create New Graph"]').first();
+      if (!(await create.isVisible().catch(() => false))) test.skip(true, 'no create-graph affordance');
+      await create.click();
+      await page.waitForTimeout(700);
+
+      const dialog = page.locator('[role="dialog"][aria-modal="true"]');
+      await expect(dialog, 'create-graph exposed as a modal dialog').toBeVisible();
+      expect(await tabStaysTrapped(page), 'Tab focus stays within the create-graph modal').toBe(true);
+    });
+  });
+
+  test.describe('phone', () => {
+    test.use({ viewport: { width: 390, height: 844 } });
+
+    test('create-work-item modal: focus enters, is trapped, and restores to the trigger', async ({ page }) => {
+      await openWorkspace(page, 'cards');
+      const fab = page.locator('[aria-label="New work item"]');
+      if (!(await fab.isVisible().catch(() => false))) test.skip(true, 'no create FAB');
+      await fab.click();
+      await page.waitForTimeout(1000);
+
+      const dialog = page.locator('[role="dialog"][aria-modal="true"]');
+      await expect(dialog, 'create-work-item exposed as a modal dialog').toBeVisible();
+      // Focus moved into the modal on open.
+      expect(await focusWithinDialog(page), 'focus moved into the modal on open').toBe(true);
+      // Tab is trapped within it.
+      expect(await tabStaysTrapped(page), 'Tab focus stays within the create modal').toBe(true);
+
+      // Close via the backdrop (the dialog-manager defers Escape while a text field
+      // is focused, by design). Focus-restore fires regardless of how it closes.
+      await page.mouse.click(5, 5);
+      await page.waitForTimeout(600);
+      await expect(dialog, 'modal closed').toHaveCount(0);
+      const restored = await page.evaluate(
+        () => document.activeElement?.getAttribute('aria-label') === 'New work item'
+      );
+      expect(restored, 'focus restored to the New-work-item trigger').toBe(true);
+    });
+  });
+});

--- a/tests/e2e/a11y-focus.spec.ts
+++ b/tests/e2e/a11y-focus.spec.ts
@@ -26,24 +26,31 @@ const focusWithinDialog = (page: Page) =>
     return !!d && !!document.activeElement && d.contains(document.activeElement);
   });
 
-/** Focus the first focusable in the dialog, then Tab `presses` times; focus must
- *  stay inside the dialog the whole time (the trap). Returns true if it never escaped. */
-async function tabStaysTrapped(page: Page, presses = 14): Promise<boolean> {
-  await page.evaluate((sel) => {
+async function focusEdge(page: Page, which: 'first' | 'last') {
+  await page.evaluate(({ sel, which }) => {
     const d = document.querySelector('[role="dialog"][aria-modal="true"]');
-    const f = d?.querySelector(sel) as HTMLElement | null;
-    f?.focus();
-  }, FOCUSABLE);
-  for (let i = 0; i < presses; i++) {
-    await page.keyboard.press('Tab');
-    if (!(await focusWithinDialog(page))) return false;
-  }
-  // and a few back-tabs
-  for (let i = 0; i < 4; i++) {
-    await page.keyboard.press('Shift+Tab');
-    if (!(await focusWithinDialog(page))) return false;
-  }
-  return true;
+    if (!d) return;
+    const items = Array.from(d.querySelectorAll(sel)).filter(
+      (e) => (e as HTMLElement).getClientRects().length > 0
+    ) as HTMLElement[];
+    (which === 'first' ? items[0] : items[items.length - 1])?.focus();
+  }, { sel: FOCUSABLE, which });
+}
+
+/**
+ * Prove the trap AT THE BOUNDARY: Tab from the last focusable must wrap back
+ * inside the dialog, and Shift+Tab from the first must wrap to the last. This
+ * is the case that fails without the trap — pressing Tab a fixed number of
+ * times never reaches the edge on a modal with many focusables, so it would
+ * pass even with the trap removed.
+ */
+async function tabStaysTrapped(page: Page): Promise<boolean> {
+  await focusEdge(page, 'last');
+  await page.keyboard.press('Tab');
+  if (!(await focusWithinDialog(page))) return false;
+  await focusEdge(page, 'first');
+  await page.keyboard.press('Shift+Tab');
+  return focusWithinDialog(page);
 }
 
 test.describe('modal a11y: role + focus trap + restore @a11y', () => {
@@ -93,13 +100,19 @@ test.describe('modal a11y: role + focus trap + restore @a11y', () => {
       await openWorkspace(page, 'cards');
       const fab = page.locator('[aria-label="New work item"]');
       if (!(await fab.isVisible().catch(() => false))) test.skip(true, 'no create FAB');
+      // Focus the trigger first so the "restore to trigger" expectation is deterministic.
+      await fab.focus();
       await fab.click();
       await page.waitForTimeout(1000);
 
       const dialog = page.locator('[role="dialog"][aria-modal="true"]');
       await expect(dialog, 'create-work-item exposed as a modal dialog').toBeVisible();
-      // Focus moved into the modal on open.
+      // Focus moved INTO the modal (and off the trigger) on open.
       expect(await focusWithinDialog(page), 'focus moved into the modal on open').toBe(true);
+      const onFabWhileOpen = await page.evaluate(
+        () => document.activeElement?.getAttribute('aria-label') === 'New work item'
+      );
+      expect(onFabWhileOpen, 'focus left the trigger while the modal is open').toBe(false);
       // Tab is trapped within it.
       expect(await tabStaysTrapped(page), 'Tab focus stays within the create modal').toBe(true);
 


### PR DESCRIPTION
## What

Implements the keyboard-accessibility behavior modals were missing, plus the `@a11y` test category that locks it in.

**`hooks/useModalA11y`** (new shared hook): marks a modal `role="dialog" aria-modal="true"` with an accessible name, moves focus into it on open, **traps Tab/Shift+Tab** within it, and **restores focus to the trigger** on close. Pairs with `useDialog` (Escape / click-outside).

Applied to **CreateWorkItemModal**, **CreateGraphModal**, and **WorkItemDetailsModal** (the details modal keeps its own container focus; fixed its `aria-labelledby`→`aria-label` so the accessible name isn't the title input's value).

### Why
Discovery (a parallel audit of every modal) found nearly all of them had **no `role=dialog`, no focus trap, and no focus restore** — you could Tab straight out of an open modal into the graph behind it, and keyboard focus never came back to where you were. Real keyboard friction.

### `@a11y` suite — `tests/e2e/a11y-focus.spec.ts`
- details modal: `role=dialog` + accessible name + Tab trapped
- create-graph modal: `role=dialog` + Tab trapped
- create-work-item modal: focus enters on open, Tab trapped, **focus restored to the FAB on close**

## Verification
- `@a11y` 3/3 pass; typecheck clean.
- No regressions: smoke **5/5**, `@dismissal` + `@zorder` **25/25** (same modals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)