### PR TITLE
test(z-order): harden overlay audits (empty/off-screen guard, stable filter testid)

### DIFF
--- a/packages/web/src/components/ViewManager.tsx
+++ b/packages/web/src/components/ViewManager.tsx
@@ -428,7 +428,7 @@ const ViewManager: React.FC<ViewManagerProps> = ({ viewMode }) => {
                 </button>
 
                 {isTypeDropdownOpen && (
-                  <div className="absolute top-full left-0 mt-2 w-full bg-gray-700 border border-gray-600 rounded-lg shadow-2xl z-50 max-h-80 overflow-y-auto">
+                  <div data-testid="filter-dropdown" className="absolute top-full left-0 mt-2 w-full bg-gray-700 border border-gray-600 rounded-lg shadow-2xl z-50 max-h-80 overflow-y-auto">
                     <div className="p-2">
                       {typeOptions.map((option, index) => (
                         <button
@@ -502,7 +502,7 @@ const ViewManager: React.FC<ViewManagerProps> = ({ viewMode }) => {
                 </button>
 
                 {isStatusDropdownOpen && (
-                  <div className="absolute top-full left-0 mt-2 w-full bg-gray-700 border border-gray-600 rounded-lg shadow-2xl z-50 max-h-80 overflow-y-auto">
+                  <div data-testid="filter-dropdown" className="absolute top-full left-0 mt-2 w-full bg-gray-700 border border-gray-600 rounded-lg shadow-2xl z-50 max-h-80 overflow-y-auto">
                     <div className="p-2">
                       {statusOptions.map((option, index) => (
                         <button
@@ -574,7 +574,7 @@ const ViewManager: React.FC<ViewManagerProps> = ({ viewMode }) => {
                 </button>
 
                 {isPriorityDropdownOpen && (
-                  <div className="absolute top-full left-0 mt-2 w-full bg-gray-700 border border-gray-600 rounded-lg shadow-2xl z-50 max-h-80 overflow-y-auto">
+                  <div data-testid="filter-dropdown" className="absolute top-full left-0 mt-2 w-full bg-gray-700 border border-gray-600 rounded-lg shadow-2xl z-50 max-h-80 overflow-y-auto">
                     <div className="p-2">
                       {priorityOptions.map((option, index) => (
                         <button
@@ -639,7 +639,7 @@ const ViewManager: React.FC<ViewManagerProps> = ({ viewMode }) => {
                 </button>
 
                 {isContributorDropdownOpen && (
-                  <div className="absolute top-full left-0 mt-2 w-full bg-gray-700 border border-gray-600 rounded-lg shadow-2xl z-50 max-h-80 overflow-y-auto">
+                  <div data-testid="filter-dropdown" className="absolute top-full left-0 mt-2 w-full bg-gray-700 border border-gray-600 rounded-lg shadow-2xl z-50 max-h-80 overflow-y-auto">
                     <div className="p-2">
                       {contributorOptions.map((option, index) => (
                         <button

--- a/tests/e2e/overlay-dismissal.spec.ts
+++ b/tests/e2e/overlay-dismissal.spec.ts
@@ -28,7 +28,8 @@ async function firstInViewport(page: Page, selector: string) {
     const el = loc.nth(i);
     if (!(await el.isVisible().catch(() => false))) continue;
     const box = await el.boundingBox().catch(() => null);
-    if (box && box.x >= 0 && box.y >= 0 && box.x + box.width <= vp.width + 1 && box.y + box.height <= vp.height + 1) return el;
+    // A few px of slack so sub-pixel/CI-rendering overflow doesn't silently skip a real trigger.
+    if (box && box.x >= -4 && box.y >= -4 && box.x + box.width <= vp.width + 4 && box.y + box.height <= vp.height + 4) return el;
   }
   return null;
 }

--- a/tests/e2e/z-order.spec.ts
+++ b/tests/e2e/z-order.spec.ts
@@ -51,7 +51,8 @@ async function firstInViewport(page: Page, selector: string) {
     const el = loc.nth(i);
     if (!(await el.isVisible().catch(() => false))) continue;
     const box = await el.boundingBox().catch(() => null);
-    if (box && box.x >= 0 && box.y >= 0 && box.x + box.width <= vp.width + 1 && box.y + box.height <= vp.height + 1) return el;
+    // A few px of slack so sub-pixel/CI-rendering overflow doesn't silently skip a real trigger.
+    if (box && box.x >= -4 && box.y >= -4 && box.x + box.width <= vp.width + 4 && box.y + box.height <= vp.height + 4) return el;
   }
   return null;
 }
@@ -60,6 +61,9 @@ async function firstInViewport(page: Page, selector: string) {
 async function assertOnTop(page: Page, selector: string, label: string) {
   const r = await auditOnTop(page, selector);
   expect(r.found, `${label}: overlay present (${selector})`).toBe(true);
+  // A collapsed (zero-size) or off-screen overlay must NOT count as "on top".
+  expect(r.empty, `${label}: overlay has real size (not collapsed)`).toBeFalsy();
+  expect(r.fitsViewport, `${label}: overlay fits within the viewport`).toBe(true);
   expect(r.coveredBy, `${label} is covered by: ${fmt(r.coveredBy)}`).toEqual([]);
   return r;
 }
@@ -108,7 +112,7 @@ test.describe('z-order: overlays render on top @zorder', () => {
           if (!(await btn.isVisible().catch(() => false))) continue;
           await btn.click();
           await page.waitForTimeout(400);
-          await assertOnTop(page, '.absolute.top-full.z-50', `filter "${label}" dropdown`);
+          await assertOnTop(page, '[data-testid="filter-dropdown"]', `filter "${label}" dropdown`);
           await btn.click().catch(() => {}); // toggle closed before the next one
           await page.waitForTimeout(200);
           tested++;


### PR DESCRIPTION
## What

Hardens the already-merged `@zorder` / `@dismissal` suites against false confidence, from an adversarial review of the audit logic.

- **`assertOnTop` now fails on a collapsed or off-screen overlay.** Previously `auditOnTop` returned `{empty:true, coveredBy:[]}` for a zero-size panel and the assertion only checked `coveredBy` — so a dropdown/modal that rendered collapsed (a real bug) passed. Now `empty` must be falsy and `fitsViewport` true.
- **Stable filter-dropdown testid.** The filter test audited `.absolute.top-full.z-50`, a class trio shared by several components (Calendar/Gantt/the create-modal status dropdown) — `querySelector` could grade the wrong panel. Added `data-testid="filter-dropdown"` (ViewManager) and audit that.
- **`firstInViewport` tolerance.** Gave the on-screen-trigger gate a few px of slack so sub-pixel/CI-rendering overflow doesn't silently `test.skip()` a real trigger.

## Verification
- `@zorder` + `@dismissal` 25/25 pass with the stricter assertions on local dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)