### PR TITLE
chore(brand): "management" not "project management"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code when working with GraphDone-Core.
 
 ## Project Overview
 
-GraphDone is a graph-native project management system that reimagines work coordination through dependencies and democratic prioritization rather than hierarchical assignments. Currently in active development (v0.3.1-alpha) with TLS/SSL production readiness.
+GraphDone is a graph-native management system that reimagines work coordination through dependencies and democratic prioritization rather than hierarchical assignments. Currently in active development (v0.3.1-alpha) with TLS/SSL production readiness.
 
 ## Core Philosophy
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GraphDone
 
-> Project management for teams who think differently. Coordinate through dependencies and outcomes, not hierarchies and top-down control.
+> Management for teams who think differently. Coordinate through dependencies and outcomes, not hierarchies and top-down control.
 
 ![GraphDone's living graph — priority glow, breathing nodes, energy flowing along dependencies](./docs/graphdone_ui.png)
 
@@ -12,7 +12,7 @@
 
 ## What is GraphDone?
 
-GraphDone reimagines project management as a collaborative graph where work flows through natural dependencies rather than artificial hierarchies. It's designed for high-quality individual contributors who thrive on autonomy, teams that include AI agents, and organizations ready to embrace democratic coordination.
+GraphDone reimagines management as a collaborative graph where work flows through natural dependencies rather than artificial hierarchies. It's designed for high-quality individual contributors who thrive on autonomy, teams that include AI agents, and organizations ready to embrace democratic coordination.
 
 **Key Features:**
 - 🌊 **A living graph** - in-progress work breathes, priority glows, energy flows along dependencies, completed work celebrates. The graph feels inhabited, not diagrammed

--- a/docs/agent-planning-scenarios.md
+++ b/docs/agent-planning-scenarios.md
@@ -521,7 +521,7 @@ Syntax: "Let me analyze the current technical architecture..."
 
 Spark: "While Syntax checks tech readiness, I'll research the competitive landscape..."
 → Tool Call: web_search.search({
-    query: "SaaS project management tools market 2025 competitors pricing",
+    query: "SaaS management tools market 2025 competitors pricing",
     max_results: 5
   })
 → Tool Response: Top competitors: Monday.com ($8-16/user), Asana ($10-24/user), Notion ($8-16/user)

--- a/docs/ai-agents-tech-spec.md
+++ b/docs/ai-agents-tech-spec.md
@@ -1159,7 +1159,7 @@ class AgentManager {
     agent.conversationHistory.push({ role: 'user', content: userMessage });
     
     // Build context-aware prompt
-    const systemPrompt = `You are ${agent.name}, a helpful AI assistant working in GraphDone, a graph-based project management system. Your personality is ${agent.personality}. 
+    const systemPrompt = `You are ${agent.name}, a helpful AI assistant working in GraphDone, a graph-based management system. Your personality is ${agent.personality}. 
     
 Current context:
 - You are currently at position (${agent.position.x}, ${agent.position.y}) on the graph
@@ -1435,7 +1435,7 @@ Respond naturally and helpfully, offering insights about the user's work and sug
     });
     
     // Build context-aware prompt for planning with tools
-    const planningPrompt = `You are a helpful AI assistant working in GraphDone, a graph-based project management system.
+    const planningPrompt = `You are a helpful AI assistant working in GraphDone, a graph-based management system.
 
 User wants you to plan: "${prompt}"
 Target node: "${targetNodeId}"  

--- a/docs/detailed-overview.md
+++ b/docs/detailed-overview.md
@@ -15,7 +15,7 @@
 
 ### The Core Concept: Work as a Graph
 
-Traditional project management tools organize work in linear lists or hierarchical trees. GraphDone models work as it actually exists - a network of interconnected outcomes, dependencies, and relationships.
+Traditional management tools organize work in linear lists or hierarchical trees. GraphDone models work as it actually exists - a network of interconnected outcomes, dependencies, and relationships.
 
 ```mermaid
 graph TD

--- a/docs/guides/architecture-overview.md
+++ b/docs/guides/architecture-overview.md
@@ -29,7 +29,7 @@ graph TB
     
     subgraph "Data Layer"
         SQLITE[(SQLite<br/>User authentication<br/>User settings & preferences<br/>Fast local storage)]
-        NEO4J[(Neo4j 5.15-community<br/>Project management graph<br/>Work items & dependencies<br/>APOC plugins<br/>Port 7687)]
+        NEO4J[(Neo4j 5.15-community<br/>Management graph<br/>Work items & dependencies<br/>APOC plugins<br/>Port 7687)]
         REDIS[(Redis 8-alpine<br/>Available in Docker<br/>Not yet integrated<br/>Port 6379)]
     end
     
@@ -234,7 +234,7 @@ GraphDone uses a hybrid database approach, optimizing each database for its spec
 - No network latency for auth operations
 
 **Neo4j: Graph Data**
-- Project management nodes (tasks, outcomes, milestones)
+- Management nodes (tasks, outcomes, milestones)
 - Dependencies and relationships between work items
 - Graph traversal and pathfinding operations
 - Complex graph queries and analytics

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with GraphDone
 
-Welcome to GraphDone! This guide will help you set up and start using GraphDone for your team's project management needs.
+Welcome to GraphDone! This guide will help you set up and start using GraphDone for your team's management needs.
 
 ## Prerequisites
 

--- a/docs/guides/user-flows.md
+++ b/docs/guides/user-flows.md
@@ -4,7 +4,7 @@
 
 ### 1. New User Onboarding Flow
 
-Understanding how users first experience GraphDone's unique approach to project management.
+Understanding how users first experience GraphDone's unique approach to management.
 
 ```mermaid
 journey
@@ -391,4 +391,4 @@ graph LR
     style L3 fill:#f3e5f5
 ```
 
-These user flows demonstrate how GraphDone's unique approach to project management creates natural, intuitive workflows that scale from individual contributors to large organizations while maintaining the core principles of democratic coordination and human-AI collaboration.
+These user flows demonstrate how GraphDone's unique approach to management creates natural, intuitive workflows that scale from individual contributors to large organizations while maintaining the core principles of democratic coordination and human-AI collaboration.

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -4,7 +4,7 @@
 
 ## The Problem We're Solving
 
-Traditional project management tools assume people work best when told what to do, when to do it, and how to do it. They optimize for management visibility and control rather than human autonomy and natural work patterns. This creates friction for high-quality individual contributors who thrive on intrinsic motivation, creative problem-solving, and peer collaboration.
+Traditional management tools assume people work best when told what to do, when to do it, and how to do it. They optimize for management visibility and control rather than human autonomy and natural work patterns. This creates friction for high-quality individual contributors who thrive on intrinsic motivation, creative problem-solving, and peer collaboration.
 
 These tools particularly fail people who think differently - those with pathological demand avoidance, autism, ADHD, or anyone who experiences traditional hierarchical structures as oppressive rather than helpful. The result is talented individuals either struggling within systems designed against their natural patterns, or being excluded entirely from collaborative work.
 
@@ -141,8 +141,8 @@ We envision a world where:
 - **Teams self-organize** around shared outcomes
 - **Technology amplifies** human agency rather than replacing it
 
-GraphDone is our contribution to this future - a tool that respects how people actually think, work, and collaborate while providing the coordination benefits of modern project management.
+GraphDone is our contribution to this future - a tool that respects how people actually think, work, and collaborate while providing the coordination benefits of modern management.
 
 From todo lists to todone lists. From directives to explorations. From control to connection.
 
-This is project management for people who think differently, built by people who think differently, in service of a more inclusive and effective future of work.
+This is management for people who think differently, built by people who think differently, in service of a more inclusive and effective future of work.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graphdone",
   "version": "0.3.1-alpha",
-  "description": "Project management for teams who think differently",
+  "description": "Management for teams who think differently",
   "private": true,
   "workspaces": [
     "packages/*",

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -11,7 +11,7 @@ This MCP (Model Context Protocol) server acts as a bridge between Claude Code an
 
 ## What You Get
 
-Transform how you interact with your project management graph:
+Transform how you interact with your management graph:
 
 - 🔍 **Smart Browsing**: Query nodes by type, status, contributor, priority, or search terms
 - ➕ **Easy Creation**: Create tasks, epics, bugs, and features through conversation

--- a/packages/server/src/auth/email-service.ts
+++ b/packages/server/src/auth/email-service.ts
@@ -160,7 +160,7 @@ class EmailService {
 
           <div class="footer">
             <p>If you didn't request this link, you can safely ignore this email.</p>
-            <p>GraphDone - Project management for teams who think differently</p>
+            <p>GraphDone - Management for teams who think differently</p>
           </div>
         </div>
       </body>
@@ -275,7 +275,7 @@ class EmailService {
 
           <div class="footer">
             <p>If you didn't request this password reset, you can safely ignore this email.</p>
-            <p>GraphDone - Project management for teams who think differently</p>
+            <p>GraphDone - Management for teams who think differently</p>
           </div>
         </div>
       </body>

--- a/packages/server/src/services/onboarding.ts
+++ b/packages/server/src/services/onboarding.ts
@@ -46,7 +46,7 @@ export const WELCOME_NODES: OnboardingNode[] = [
     title: 'Welcome to GraphDone!',
     description: `# Welcome to GraphDone! 🎉
 
-GraphDone is a graph-native project management system that reimagines how work flows through dependencies rather than hierarchies.
+GraphDone is a graph-native management system that reimagines how work flows through dependencies rather than hierarchies.
 
 ## Key Concepts:
 - **Nodes** represent work items, ideas, tasks, or outcomes

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -7,8 +7,8 @@
     <meta name="theme-color" content="#6366f1" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <link rel="manifest" href="/manifest.json" />
-    <title>GraphDone - Project Management Reimagined</title>
-    <meta name="description" content="Project management for teams who think differently. Coordinate through dependencies and outcomes, not hierarchies and top-down control." />
+    <title>GraphDone - Management, Reimagined</title>
+    <meta name="description" content="Management for teams who think differently. Coordinate through dependencies and outcomes, not hierarchies and top-down control." />
   </head>
   <body>
     <div id="root">

--- a/packages/web/public/manifest.json
+++ b/packages/web/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "GraphDone",
   "short_name": "GraphDone",
-  "description": "Graph-native project management system",
+  "description": "Graph-native management system",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#ffffff",

--- a/packages/web/src/pages/Signup.tsx
+++ b/packages/web/src/pages/Signup.tsx
@@ -299,7 +299,7 @@ export function Signup() {
             <span className="ml-3 sm:ml-4 text-4xl sm:text-5xl font-bold bg-gradient-to-r from-teal-400 via-cyan-400 to-blue-500 bg-clip-text text-transparent drop-shadow-2xl tracking-tight">GraphDone</span>
           </Link>
           <h1 className="text-3xl font-bold text-gray-100 mb-3">Create Your Account</h1>
-          <p className="text-gray-400 text-lg">Join the decentralized project management revolution</p>
+          <p className="text-gray-400 text-lg">Join the decentralized management revolution</p>
         </div>
 
         {/* Email Verification Screen or Signup Form */}

--- a/packages/web/src/types/projectData.ts
+++ b/packages/web/src/types/projectData.ts
@@ -1,4 +1,4 @@
-// Project management specific types and mock data
+// Management specific types and mock data
 
 export type RelationshipType = 
   | 'DEPENDS_ON'      // This node depends on another to be completed
@@ -50,7 +50,7 @@ export interface MockEdge {
   createdAt: string;
 }
 
-// Mock project management data
+// Mock management data
 export const mockProjectNodes: MockNode[] = [
   {
     id: 'epic-1',


### PR DESCRIPTION
Rebrands away from *project management* (and *project management revolution*) to a short, general **management** framing — we manage projects, requirements, and more, without being an 'everything tool'. User-facing copy (page title → "Management, Reimagined", meta, manifest, package description, README tagline, Signup hero, email footers, onboarding) + docs. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)