### PR TITLE
BRAND-1: finish rebrand to "management" (non-SPA surfaces)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,7 +281,7 @@ const GraphView = () => {
 };
 ```
 
-## Current UI Evolution: Slick Dialog Revolution
+## Contextual Dialog Direction (slick inline editors)
 
 GraphDone is undergoing a **major UI transformation** moving away from heavy modal dialogs toward slick, contextual, inline-style editors. This shift prioritizes **immediate feedback, minimal context switching, and delightful micro-interactions**.
 

--- a/public/install.sh
+++ b/public/install.sh
@@ -10,7 +10,7 @@
 #
 # 📖 DESCRIPTION
 # ============================================================================
-#   Automated installer for GraphDone - a graph-native project management
+#   Automated installer for GraphDone - a graph-native management
 #   system that reimagines work coordination through dependencies and
 #   democratic prioritization. Handles complete setup from dependency
 #   installation to running services with beautiful CLI progress feedback.

--- a/start
+++ b/start
@@ -60,7 +60,7 @@ detect_platform
 
 # Help function
 show_help() {
-    echo -e "${BOLD}GraphDone${NC} - Graph-native project management system"
+    echo -e "${BOLD}GraphDone${NC} - Graph-native management system"
     echo ""
     echo -e "${BOLD}USAGE:${NC}"
     echo "  ./start [COMMAND] [OPTIONS]"
@@ -196,7 +196,7 @@ show_banner() {
         echo "║                                                              ║"
         echo "║                     🌐 GraphDone 🌐                          ║"
         echo "║                                                              ║"
-        echo "║           Graph-native project management system             ║"
+        echo "║                Graph-native management system                ║"
         echo "║                                                              ║"
         echo "╚══════════════════════════════════════════════════════════════╝"
         echo -e "${NC}"

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -735,7 +735,7 @@ function generateHTMLReport() {
                 </div>
                 <div>
                     <h1>GraphDone Test Report</h1>
-                    <div class="subtitle">Comprehensive testing results for graph-native project management</div>
+                    <div class="subtitle">Comprehensive testing results for graph-native management</div>
                     <div class="meta">
                         Generated: ${new Date().toLocaleString()} | 
                         Environment: <strong>${testResults.environment}</strong> | 

--- a/tools/document.sh
+++ b/tools/document.sh
@@ -133,7 +133,7 @@ if [ "$BUILD_DOCS" = true ]; then
     </ul>
     
     <h2>Project Overview</h2>
-    <p>GraphDone reimagines project management as a collaborative graph where work flows through natural dependencies rather than artificial hierarchies.</p>
+    <p>GraphDone reimagines management as a collaborative graph where work flows through natural dependencies rather than artificial hierarchies.</p>
     
     <h3>Key Features</h3>
     <ul>


### PR DESCRIPTION
## What
The SPA was already rebranded; this finishes the developer-facing surfaces so the wording is consistent everywhere and drops the "revolution" framing.

- `start` — CLI help line + ASCII banner → "Graph-native management system" (banner re-centred to keep the box aligned)
- `public/install.sh` — installer description comment
- `tools/document.sh` — generated overview ("reimagines management as a collaborative graph…")
- `tests/run-all-tests.js` — HTML report subtitle
- `CLAUDE.md` — "Slick Dialog Revolution" → "Contextual Dialog Direction (slick inline editors)"

No "project management", no "everything tool" — short, descriptive, general **management**.

## Verification
Repo-wide grep for `project[ -]?management|\brevolution|everything tool` (excluding deps/build/artifacts) → **0 hits** in Core. Non-code files only (scripts/docs/report), no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)