### PR TITLE
SEC: disable production source maps (no public .js.map)

### DIFF
--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -63,7 +63,10 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
-    sourcemap: true,
+    // No production source maps — serving .js.map publicly leaks original source.
+    // Caught by the live red-team (REDTEAM-SEC). Dev uses the Vite dev server
+    // (its own maps), so debugging is unaffected.
+    sourcemap: false,
     rollupOptions: {
       output: {
         // Force new filenames to break cache


### PR DESCRIPTION
Live red-team caught public .js.map on prod (leaks source). vite build sourcemap:true → false; dev unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)