### PR TITLE
Unique test id per GraphSelector mount (fix strict-mode collision)

### DIFF
--- a/packages/web/src/components/GraphSelector.tsx
+++ b/packages/web/src/components/GraphSelector.tsx
@@ -10,9 +10,13 @@ interface GraphSelectorProps {
   onCreateGraph?: () => void;
   onEditGraph?: (graph: any) => void;
   onDeleteGraph?: (graph: any) => void;
+  // GraphSelector is mounted in 2–3 responsive slots at once (sidebar, phone
+  // top-bar, workspace top-bar); each needs a distinct test id so selectors stay
+  // unique. Defaults to the canonical 'graph-selector' (the workspace mount).
+  testId?: string;
 }
 
-export function GraphSelector({ onCreateGraph, onEditGraph, onDeleteGraph }: GraphSelectorProps) {
+export function GraphSelector({ onCreateGraph, onEditGraph, onDeleteGraph, testId = 'graph-selector' }: GraphSelectorProps) {
   const { currentGraph, graphHierarchy, selectGraph } = useGraph();
   const { currentTeam, currentUser } = useAuth();
   const [isOpen, setIsOpen] = useState(false);
@@ -229,7 +233,7 @@ export function GraphSelector({ onCreateGraph, onEditGraph, onDeleteGraph }: Gra
       <button
         ref={buttonRef}
         onClick={toggleDropdown}
-        data-testid="graph-selector"
+        data-testid={testId}
         className="flex items-center space-x-3 w-full p-3 text-left hover:bg-gray-700/80 rounded-xl transition-all duration-200 hover:scale-[1.02] border border-gray-600/30 hover:border-gray-500/50 shadow-lg hover:shadow-xl backdrop-blur-sm bg-gray-800/50"
       >
         <div className="flex-shrink-0">

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -54,7 +54,7 @@ export function Layout({ children }: LayoutProps) {
         <div className="md:hidden relative z-30 pt-safe">
           <div className="flex items-center bg-gray-800/90 backdrop-blur-sm px-3 py-2 border-b border-gray-700/50">
             <div className="flex-1 min-w-0">
-              <GraphSelector />
+              <GraphSelector testId="graph-selector-mobile" />
             </div>
           </div>
         </div>
@@ -166,7 +166,7 @@ export function Layout({ children }: LayoutProps) {
             {/* Graph Selector */}
             {!desktopSidebarCollapsed && (
               <div className="border-t border-gray-700">
-                <GraphSelector />
+                <GraphSelector testId="graph-selector-sidebar" />
               </div>
             )}
 


### PR DESCRIPTION
GraphSelector mounts in up to 3 responsive slots at once (sidebar, phone top-bar, workspace top-bar), each hard-coding `data-testid="graph-selector"` → duplicate test id in the DOM → strict-mode selector violations (broke the shared `navigateToWorkspace` E2E helper). Adds a `testId` prop (default `graph-selector` = canonical workspace mount); sidebar/phone get `graph-selector-sidebar`/`graph-selector-mobile`.

Surfaced by a dogfood session driving the live dev stack. Verified: web typecheck; THE GATE 5/5; `getByTestId('graph-selector')` resolves to exactly 1; 0 page/GraphQL errors in session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)