### PR TITLE
fix(dashboard): drop -1 fps sentinels from large-graph trends

### DIFF
--- a/tests/lib/dashboard/dashboard.test.mjs
+++ b/tests/lib/dashboard/dashboard.test.mjs
@@ -156,6 +156,13 @@ test('scaleSweepMetrics drops -1 not-measured sentinels', () => {
   assert.equal(m.find((x) => x.metric === 'graph.loadMs').value, 1200);
   assert.equal(m.find((x) => x.metric === 'graph.settleMs').value, 0);
 });
+test('largeGraphMetrics drops -1 not-measured fps sentinels', () => {
+  const m = largeGraphMetrics({ quality: 'HIGH', graph: 'g', idleFps: 60, panFps: 55, dragFps: -1, zoomFps: 48, zoomedInDragFps: -1 }, 123);
+  assert.equal(m.find((x) => x.metric === 'graph.dragFps'), undefined, 'dragFps sentinel should be dropped');
+  assert.equal(m.find((x) => x.metric === 'graph.zoomedInDragFps'), undefined, 'zoomedInDragFps sentinel should be dropped');
+  assert.equal(m.find((x) => x.metric === 'graph.idleFps').value, 60);
+  assert.equal(m.length, 3);
+});
 test('largeGraphMetrics + physicsMetrics + vlmMetrics', () => {
   assert.equal(largeGraphMetrics({ quality: 'HIGH', graph: 'g', idleFps: 60, panFps: 55, dragFps: 50, zoomFps: 48, zoomedInDragFps: 40 }, 123).length, 5);
   const p = physicsMetrics({ graphId: 'g', summary: { settleSeconds: 4, overlapAfterOrganize: 0, labelOverlapAfter: 1 } }, 9);

--- a/tests/lib/dashboard/metrics.mjs
+++ b/tests/lib/dashboard/metrics.mjs
@@ -52,12 +52,15 @@ export function scaleSweepMetrics(json) {
 
 export function largeGraphMetrics(json, ts) {
   const ctx = { quality: json.quality, graph: json.graph };
+  // The large-graph profiler writes -1 for any fps it could not measure
+  // (e.g. dragFps when the node element is absent); keep those out of trends.
+  const measured = (v) => (typeof v === 'number' && v < 0 ? NaN : v);
   return [
-    pt('graph.idleFps', json.idleFps, 'fps', 'higher', ctx, ts),
-    pt('graph.panFps', json.panFps, 'fps', 'higher', ctx, ts),
-    pt('graph.dragFps', json.dragFps, 'fps', 'higher', ctx, ts),
-    pt('graph.zoomFps', json.zoomFps, 'fps', 'higher', ctx, ts),
-    pt('graph.zoomedInDragFps', json.zoomedInDragFps, 'fps', 'higher', ctx, ts),
+    pt('graph.idleFps', measured(json.idleFps), 'fps', 'higher', ctx, ts),
+    pt('graph.panFps', measured(json.panFps), 'fps', 'higher', ctx, ts),
+    pt('graph.dragFps', measured(json.dragFps), 'fps', 'higher', ctx, ts),
+    pt('graph.zoomFps', measured(json.zoomFps), 'fps', 'higher', ctx, ts),
+    pt('graph.zoomedInDragFps', measured(json.zoomedInDragFps), 'fps', 'higher', ctx, ts),
   ].filter(Boolean);
 }
 


### PR DESCRIPTION
Extends #138's sentinel guard to largeGraphMetrics (dragFps=-1 was charting as real data). +1 unit test, all 34 dashboard tests green.