### PR TITLE
fix(dashboard): drop stale -1 sentinel metrics from served trends

### DIFF
--- a/tests/lib/dashboard/dashboard.test.mjs
+++ b/tests/lib/dashboard/dashboard.test.mjs
@@ -8,7 +8,7 @@ import { rollupStatus, fmtDuration, fmtBytes, pct, decodeMungedName, esc, STATUS
 import { niceMax, bounds, lineChart, statusBar, sparkline } from './charts.mjs';
 import { isUnifiedReport, runIdFor, summarize, mediaCount, safeId } from './ingest.mjs';
 import { reportMetrics, scaleSweepMetrics, largeGraphMetrics, physicsMetrics, vlmMetrics, pointKey } from './metrics.mjs';
-import { mergeRuns, mergeMetrics, readJsonl, appendJsonl, snapshotRun, pruneSnapshots, pickLatest } from './history.mjs';
+import { mergeRuns, mergeMetrics, liveMetrics, readJsonl, appendJsonl, snapshotRun, pruneSnapshots, pickLatest } from './history.mjs';
 
 // ── format ────────────────────────────────────────────────────────────────
 test('rollupStatus: worst-of precedence', () => {
@@ -212,6 +212,19 @@ test('mergeMetrics dedupes by key', () => {
   const { merged, added } = mergeMetrics([{ key: 'a' }], [{ key: 'a' }, { key: 'b' }, { key: 'b' }]);
   assert.equal(merged.length, 2);
   assert.deepEqual(added.map((m) => m.key), ['b']);
+});
+test('liveMetrics drops stale -1 sentinels and non-finite values from stored history', () => {
+  const m = liveMetrics([
+    { metric: 'graph.driftPx', value: -1 },
+    { metric: 'graph.avgTickMs', value: -1 },
+    { metric: 'graph.driftPx', value: 85.77 },
+    { metric: 'graph.idleFps', value: 0 },
+    { metric: 'graph.loadMs', value: NaN },
+    { metric: 'suite.passRate', value: 100 },
+    null,
+  ]);
+  assert.equal(m.length, 3);
+  assert.deepEqual(m.map((x) => x.value), [85.77, 0, 100]);
 });
 
 // ── history fs round-trip ───────────────────────────────────────────────────

--- a/tests/lib/dashboard/history.mjs
+++ b/tests/lib/dashboard/history.mjs
@@ -36,6 +36,18 @@ export function pickLatest(runs) {
   return (available || runs[0]).runId;
 }
 
+/**
+ * Drop not-measured sentinels from a stored metric series before it reaches the
+ * charts. Ingestion (metrics.mjs) already filters -1 sentinels, but the
+ * append-only metrics.jsonl retains points written before that fix landed; a -1
+ * on a lower-is-better metric (driftPx, avgTickMs) otherwise reads as a perfect
+ * score and distorts the trend. Every GraphDone metric is non-negative, so a
+ * non-finite or negative value is always a sentinel.
+ */
+export function liveMetrics(metrics) {
+  return metrics.filter((m) => m && typeof m.value === 'number' && isFinite(m.value) && m.value >= 0);
+}
+
 export function mergeMetrics(existing, incoming) {
   const seen = new Set(existing.map((m) => m.key));
   const added = [];

--- a/tests/lib/dashboard/server.mjs
+++ b/tests/lib/dashboard/server.mjs
@@ -16,7 +16,7 @@ import { resolve, join, sep, extname } from 'node:path';
 import { spawn } from 'node:child_process';
 import { discover, signature, safeId, summarize } from './ingest.mjs';
 import { reportMetrics, scanPerfArtifacts } from './metrics.mjs';
-import { mergeRuns, mergeMetrics, readJsonl, appendJsonl, snapshotRun, pruneSnapshots, pickLatest } from './history.mjs';
+import { mergeRuns, mergeMetrics, liveMetrics, readJsonl, appendJsonl, snapshotRun, pruneSnapshots, pickLatest } from './history.mjs';
 import { renderShell } from './page.mjs';
 
 const args = process.argv.slice(2);
@@ -101,7 +101,7 @@ function reindex() {
 
   if (existsSync(join(STORE, 'runs'))) pruneSnapshots(STORE, KEEP);
 
-  const allMetrics = readJsonl(METRICS_JSONL);
+  const allMetrics = liveMetrics(readJsonl(METRICS_JSONL));
   state = {
     generatedAt: Date.now(),
     latest: pickLatest(merged),


### PR DESCRIPTION
## Problem
The live test dashboard still serves `-1` for `graph.driftPx` and `graph.avgTickMs` in metric trends. Ingestion already filters these (commit 24eb497 for FPS; metrics.mjs `measured()` for sweep/large-graph), but the append-only `metrics.jsonl` retains points written *before* those fixes. A `-1` on a lower-is-better metric reads as a perfect score and distorts the trend chart.

## Fix
Add `liveMetrics()` in `history.mjs` — a defensive guard at the serve layer (server.mjs:104) dropping non-finite/negative metric values. Every GraphDone metric (fps, ms, px, counts, scores) is non-negative, so a negative is always a not-measured sentinel. Dedup-on-append (server.mjs:84) keeps reading raw.

## Test
`liveMetrics` unit test added; full dashboard suite green (35/35 via `node --test`). Pure read-layer change — no app data/graph/deletion paths touched, so smoke gate is not the relevant gate.