### PR TITLE
fix(dashboard): scale-sweep drift chart no longer reads as permanent budget breach

### DIFF
--- a/tests/lib/dashboard/app.mjs
+++ b/tests/lib/dashboard/app.mjs
@@ -67,7 +67,7 @@ const CHART_DEFS = [
   { metric: 'graph.loadMs', title: 'Graph load time', unit: 'ms', budget: null },
   { metric: 'graph.avgTickMs', title: 'Sim tick cost', unit: 'ms', budget: 8 },
   { metric: 'graph.queryP95Ms', title: 'Query p95 latency', unit: 'ms', budget: 800 },
-  { metric: 'graph.driftPx', title: 'Layout drift', unit: 'px', budget: 25 },
+  { metric: 'graph.driftPx', title: 'Layout wander vs size (scale sweep)', unit: 'px' },
   { metric: 'physics.settleSeconds', title: 'Physics settle time', unit: 's' },
   { metric: 'vlm.score', title: 'VLM visual score', unit: 'score' },
 ];

--- a/tests/lib/reporting/generate-perf-report.mjs
+++ b/tests/lib/reporting/generate-perf-report.mjs
@@ -99,7 +99,7 @@ ${lineChart('Interaction FPS vs size (drag)', 'interactionFps', { unit: '' })}
 ${lineChart('Initial load vs size', 'loadMs', { unit: 'ms' })}
 ${lineChart('Avg simulation tick vs size', 'avgTickMs', { unit: 'ms', budget: 8 })}
 ${lineChart('Settle time vs size', 'settleMs', { unit: 'ms' })}
-${lineChart('Layout drift vs size', 'rmsFromSavedPx', { unit: 'px', budget: 25 })}
+${lineChart('Layout wander vs size (seed displacement)', 'rmsFromSavedPx', { unit: 'px' })}
 ${lineChart('Query p95 latency vs size', 'queryP95Ms', { unit: 'ms', budget: 800 })}
 </div>
 <h2>All metrics</h2>


### PR DESCRIPTION
The dashboard "Layout drift" trend (budget 25px) is fed **only** by scale-sweep `rmsFromSavedPx`, which measures how far force layout wanders synthetic seeded graphs from their seed positions — expected to grow with graph size, not a placed-graph fidelity signal. The real 25px fidelity guard lives in `graph-perf.spec.ts` (enforced as a test assertion). Applying that budget on the dashboard made the chart read as a permanent 136px-vs-25px breach (a documented artifact, not a regression).

This retitles the chart to "Layout wander vs size (scale sweep)" and drops the misapplied budget, in both the live dashboard and the static perf report.

Verification: `node --check` on both files + `node --test tests/lib/dashboard/dashboard.test.mjs` (39/39 pass). Framing-only change to informational charts; no app/data/graph paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)