### PR TITLE
fix(web): uniform single-column status chips (Connected/Collaborators)

### DIFF
--- a/packages/web/src/pages/Workspace.tsx
+++ b/packages/web/src/pages/Workspace.tsx
@@ -251,10 +251,10 @@ export function Workspace() {
 
           {/* Right Section: Status and Actions — hidden on mobile (the hamburger
               handles nav there); these chips otherwise eat the small-screen width. */}
-          <div className="flex flex-col items-end gap-1.5 md:order-3 md:shrink-0">
+          <div className="flex flex-col items-stretch gap-1.5 md:order-3 md:shrink-0">
             {/* Data-store status (provider-agnostic — keyed off the GraphQL API, which is
                 the actual data layer; the backing store may be D1, Neo4j, etc.) */}
-            <div className={`flex items-center gap-2 px-3 py-2 rounded-lg text-xs transition-all cursor-help ${
+            <div className={`flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-xs transition-all cursor-help ${
               health?.services?.graphql?.status === 'healthy'
                 ? 'bg-green-600/20 text-green-300 border border-green-500/30'
                 : 'bg-red-600/20 text-red-300 border border-red-500/30'


### PR DESCRIPTION
items-stretch + centered content so the two top-bar status chips form a clean, equal-width single column. typecheck + smoke 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)